### PR TITLE
feat: Add manual control config variable doc

### DIFF
--- a/components/cover/time_based.rst
+++ b/components/cover/time_based.rst
@@ -52,6 +52,11 @@ Configuration variables:
   detectors. In this configuration the ``stop_action`` is not performed when the open or close
   time is completed and if the cover is commanded to open or close the corresponding actions
   will be performed without checking current state. Defaults to ``false``.
+- **manual_control** (*Optional*, boolean): If your cover has a manual control switch, it's not 
+  possible for the system to be sure of its current position. Thus, the cover state is unsure. 
+  So whenever the cover is commanded to open or close, the command will be performed completely 
+  (including any defined ``stop_action``) and the current state will be relearned from this. 
+  Defaults to ``false``. 
 - **assumed_state** (*Optional*, boolean): Whether the true state of the cover is not known.
   This will make the Home Assistant frontend show buttons for both OPEN and CLOSE actions, instead
   of hiding or disabling one of them. Defaults to ``true``.


### PR DESCRIPTION
This allows to use a time based cover with a manual control switch. The cover state is therefore only a guess so when calling any command (open or close), the action is performed completely nevertheless. At the end of the action, the assumed state is re-synchronized with the cover position.


## Description:

Fix #2045

**Related issue (if applicable):** fixes #2045

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#4249

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
